### PR TITLE
Smoother navigation between classes when navigating up from player

### DIFF
--- a/app/lib/routes/ternary-section-route.dart
+++ b/app/lib/routes/ternary-section-route.dart
@@ -27,7 +27,7 @@ class TernarySectionRoute extends StatelessWidget {
             ? null
             : scrollToIndexRaw;
     return SectionContentList(
-        scrollIndex: scrollToIndex,
+        scrollToIndex: scrollToIndex,
         isSeperated: true,
         section: section,
         leadingWidget: Column(

--- a/app/lib/routes/ternary-section-route.dart
+++ b/app/lib/routes/ternary-section-route.dart
@@ -16,23 +16,34 @@ class TernarySectionRoute extends StatelessWidget {
   TernarySectionRoute({required this.section});
 
   @override
-  Widget build(BuildContext context) => SectionContentList(
-      isSeperated: true,
-      section: section,
-      leadingWidget: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [InsideBreadcrumbs()],
-      ),
-      sectionBuilder: (context, section) => InsideNavigator(
-            data: section,
-            child: _tile(section)
-          ),
-      lessonBuilder: (context, lesson) => _tile(lesson),
-      mediaBuilder: (context, media) => MediaItem(
-            media: media,
-            sectionId: section!.id,
-            routeDataService: BlocProvider.getDependency<LibraryPositionService>(),
-          ));
+  Widget build(BuildContext context) {
+    final lastPlayingId =
+        BlocProvider.getDependency<LibraryPositionService>().lastPlayingId;
+    final scrollToIndexRaw = section?.content.indexWhere((element) =>
+        element.media?.id != null && element.media?.id == lastPlayingId);
+    final scrollToIndex = scrollToIndexRaw == null
+        ? scrollToIndexRaw
+        : scrollToIndexRaw < 0
+            ? null
+            : scrollToIndexRaw;
+    return SectionContentList(
+        scrollIndex: scrollToIndex,
+        isSeperated: true,
+        section: section,
+        leadingWidget: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [InsideBreadcrumbs()],
+        ),
+        sectionBuilder: (context, section) =>
+            InsideNavigator(data: section, child: _tile(section)),
+        lessonBuilder: (context, lesson) => _tile(lesson),
+        mediaBuilder: (context, media) => MediaItem(
+              media: media,
+              sectionId: section!.id,
+              routeDataService:
+                  BlocProvider.getDependency<LibraryPositionService>(),
+            ));
+  }
 
   static Widget _tile(CountableSiteDataItem data) {
     var itemWord = data.audioCount! > 1 ? 'classes' : 'class';

--- a/app/lib/util/library-navigator/library-position-service.dart
+++ b/app/lib/util/library-navigator/library-position-service.dart
@@ -64,7 +64,6 @@ class LibraryPositionService extends ChangeNotifier
   void setLastPlayingId() {
     if (sections.isNotEmpty) {
       final lastData = sections.last.data;
-      print(sections.last.data is Media);
       if (lastData is Media) {
         lastPlayingId = lastData.id;
       } else {

--- a/app/lib/util/library-navigator/library-position-service.dart
+++ b/app/lib/util/library-navigator/library-position-service.dart
@@ -62,6 +62,13 @@ class LibraryPositionService extends ChangeNotifier
   }
 
   void setLastPlayingId() {
+    // If sections _is_ empty, we still do _not_ set lastPlayingId to null.
+    // If we were to do so, then it would be null at the end of the following
+    // scenario: the player is navigated to, then the user clicks on the home
+    // button, then clicks on the player button, then navigates "up" one. In
+    // this case, when navigating up, sections will be empty. By doing nothing,
+    // lastPlayingId is set when navigating to home, and persists until sections
+    // is non-empty.
     if (sections.isNotEmpty) {
       final lastData = sections.last.data;
       if (lastData is Media) {

--- a/app/lib/util/library-navigator/library-position-service.dart
+++ b/app/lib/util/library-navigator/library-position-service.dart
@@ -20,6 +20,9 @@ class LibraryPositionService extends ChangeNotifier
   final SiteBoxes siteBoxes;
   List<SitePosition> sections = [];
 
+  /// Available only when the previous screen was the player screen
+  int? lastPlayingId;
+
   LibraryPositionService({required this.siteBoxes});
 
   /// Ensure that next to last item is parent of new item, or clear the list.
@@ -31,6 +34,8 @@ class LibraryPositionService extends ChangeNotifier
       return sections;
     }
 
+    setLastPlayingId();
+
     await _clearTo(item!);
 
     notifyListeners();
@@ -38,6 +43,7 @@ class LibraryPositionService extends ChangeNotifier
   }
 
   bool removeLast() {
+    setLastPlayingId();
     if (sections.isNotEmpty) {
       sections.removeLast();
       notifyListeners();
@@ -49,8 +55,21 @@ class LibraryPositionService extends ChangeNotifier
 
   clear() {
     if (sections.isNotEmpty) {
+      setLastPlayingId();
       sections.clear();
       notifyListeners();
+    }
+  }
+
+  void setLastPlayingId() {
+    if (sections.isNotEmpty) {
+      final lastData = sections.last.data;
+      print(sections.last.data is Media);
+      if (lastData is Media) {
+        lastPlayingId = lastData.id;
+      } else {
+        lastPlayingId = null;
+      }
     }
   }
 

--- a/app/lib/widgets/section-content-list.dart
+++ b/app/lib/widgets/section-content-list.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:bloc_pattern/bloc_pattern.dart';
 import 'package:flutter/material.dart';
 import 'package:inside_api/models.dart';
 import 'package:inside_api/site-service.dart';
 import 'package:inside_chassidus/widgets/inside-navigator.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 typedef Widget InsideDataBuilder<T extends SiteDataItem>(
     BuildContext context, T data);
@@ -22,13 +25,16 @@ class SectionContentList extends StatelessWidget {
   /// If there is a leading widget, index is 1 too many.
   int get indexOffset => leadingWidget == null ? 0 : 1;
 
+  final int? scrollIndex;
+
   SectionContentList(
       {required this.section,
       required this.sectionBuilder,
       required this.lessonBuilder,
       required this.mediaBuilder,
       this.isSeperated = false,
-      this.leadingWidget});
+      this.leadingWidget,
+      this.scrollIndex});
 
   @override
   Widget build(BuildContext context) => FutureBuilder<Section>(
@@ -36,16 +42,18 @@ class SectionContentList extends StatelessWidget {
         builder: (context, snapShot) {
           if (snapShot.hasData && snapShot.data != null) {
             if (isSeperated) {
-              return ListView.separated(
+              return ScrollablePositionedList.separated(
                 padding: EdgeInsets.symmetric(horizontal: 8),
                 itemCount: snapShot.data!.content.length + indexOffset,
                 itemBuilder: _sectionContent(snapShot.data),
                 separatorBuilder: (context, i) => Divider(),
+                initialScrollIndex: scrollIndex ?? 0,
               );
             } else {
-              return ListView.builder(
+              return ScrollablePositionedList.builder(
                 itemCount: snapShot.data!.content.length + indexOffset,
                 itemBuilder: _sectionContent(snapShot.data),
+                initialScrollIndex: scrollIndex ?? 0,
               );
             }
           } else if (snapShot.hasError) {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   args:
     dependency: transitive
     description:
@@ -543,7 +543,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -677,6 +677,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.1"
+  scrollable_positioned_list:
+    dependency: "direct main"
+    description:
+      name: scrollable_positioned_list
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0-nullsafety.0"
   shelf:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
     path:
       ../just_audio_handlers
   audio_session: ^0.1.5
+  scrollable_positioned_list: ^0.2.0-nullsafety.0
 dev_dependencies:
   build_runner: ^2.0.6
   hive_generator: ^1.0.1


### PR DESCRIPTION
This PR addresses item (1) in #93.
It implements that whenever the content list is navigated "up" to from the player, the list is scrolled so the currently playing class is second to top.
In order to properly initialize the ListView at the appropriate position, it was necessary to replace the ListView with the (otherwise identical) `ScrollablePositionedList` from the `scrollable_positioned_list` package. (It was actually not possible to initialize it at the correct position, as noted in the comments, but rather the correct position is "jumped" to immediately. This unfortunately is not great UX).
Feel free to reject or modify this PR 👍.