### PR TITLE
Support for going to previous/next media in a series

### DIFF
--- a/app/lib/routes/player-route/player-route.dart
+++ b/app/lib/routes/player-route/player-route.dart
@@ -8,36 +8,17 @@ import 'package:inside_chassidus/widgets/media/audio-button-bar.dart';
 import 'package:inside_data_flutter/inside_data_flutter.dart';
 import 'package:just_audio_handlers/just_audio_handlers.dart';
 
-class PlayerRoute extends StatefulWidget {
+class PlayerRoute extends StatelessWidget {
   static const String routeName = '/library/playerroute';
 
   final Media media;
+  final SiteDataLayer _siteBoxes = BlocProvider.getDependency<SiteDataLayer>();
+  
+  final libraryPositionService =
+    BlocProvider.getDependency<LibraryPositionService>();
 
 
   PlayerRoute({required this.media});
-
-  @override
-  State<PlayerRoute> createState() => _PlayerRouteState();
-}
-
-class _PlayerRouteState extends State<PlayerRoute> {
-  final SiteDataLayer _siteBoxes = BlocProvider.getDependency<SiteDataLayer>();
-
-  final libraryPositionService =
-      BlocProvider.getDependency<LibraryPositionService>();
-
-  late Media _currMedia;
-
-  @override
-  void initState() {
-    super.initState();
-    _currMedia = widget.media;
-  }
-
-  void _changeMedia(Media media) {
-    if (mounted)
-      setState(() => _currMedia = media);
-  }
 
   @override
   Widget build(BuildContext context) => Container(
@@ -51,7 +32,7 @@ class _PlayerRouteState extends State<PlayerRoute> {
                   child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.center,
-                children: _title(context, _currMedia),
+                children: _title(context, media),
               )),
             ]),
             _description(context),
@@ -69,14 +50,14 @@ class _PlayerRouteState extends State<PlayerRoute> {
                         icon: Icon(
                           icon,
                         )),
-                    audioSource: _currMedia.source,
+                    audioSource: media.source,
                     downloader: BlocProvider.getDependency<AudioDownloader>(),
                   )
                 ],
               ),
             ),
             ProgressBar(
-              media: _currMedia,
+              media: media,
             ),
             _audioButtonBar()
           ],
@@ -85,7 +66,7 @@ class _PlayerRouteState extends State<PlayerRoute> {
 
   FutureBuilder<SiteDataBase?> _navigateToLibraryButton() =>
       FutureBuilder<SiteDataBase?>(
-        future: _currMedia.getParent(_siteBoxes),
+        future: media.getParent(_siteBoxes),
         builder: (context, snapshot) => snapshot.data != null
             ? IconButton(
                 padding: EdgeInsets.zero,
@@ -99,19 +80,15 @@ class _PlayerRouteState extends State<PlayerRoute> {
 
   FutureBuilder<Section?> _audioButtonBar() {
     return FutureBuilder<Section?>(
-        future: _currMedia.getParent(_siteBoxes),
+        future: media.getParent(_siteBoxes),
         builder: (context, snapshot) {
-          Media? nextMedia = _currMedia.getRelativeSibling(snapshot.data, 1);
-          Media? prevMedia = _currMedia.getRelativeSibling(snapshot.data, -1);
+          Media? nextMedia = media.getRelativeSibling(snapshot.data, 1);
+          Media? prevMedia = media.getRelativeSibling(snapshot.data, -1);
 
           return AudioButtonBar(
-            media: this._currMedia,
+            media: this.media,
             nextMedia: nextMedia,
-            onChangedToNextMedia: nextMedia == null ? null :
-                () => _changeMedia(nextMedia),
             previousMedia: prevMedia,
-            onChangedToPreviousMedia: prevMedia == null ? null :
-                () => _changeMedia(prevMedia),
           );
         }
     );
@@ -120,9 +97,9 @@ class _PlayerRouteState extends State<PlayerRoute> {
   /// Returns lesson title and media title.
   /// If the media doesn't have a title, just returns lesson title as title.
   List<Widget> _title(BuildContext context, SiteDataBase lesson) {
-    if ((_currMedia.title.isNotEmpty) &&
+    if ((media.title.isNotEmpty) &&
         (lesson.title.isNotEmpty) &&
-        _currMedia.title != lesson.title) {
+        media.title != lesson.title) {
       return [
         Container(
           margin: EdgeInsets.only(bottom: 8),
@@ -133,7 +110,7 @@ class _PlayerRouteState extends State<PlayerRoute> {
           ),
         ),
         Text(
-          _currMedia.title,
+          media.title,
           style: Theme.of(context).textTheme.headline1,
         )
       ];
@@ -141,7 +118,7 @@ class _PlayerRouteState extends State<PlayerRoute> {
 
     return [
       Text(
-        _currMedia.title.isNotEmpty ? _currMedia.title : lesson.title,
+        media.title.isNotEmpty ? media.title : lesson.title,
         style: Theme.of(context).textTheme.headline6,
       )
     ];
@@ -155,7 +132,7 @@ class _PlayerRouteState extends State<PlayerRoute> {
           child: Container(
             margin: EdgeInsets.only(top: 8),
             child: Text(
-              _currMedia.description,
+              media.description,
               style: Theme.of(context).textTheme.bodyText2,
             ),
           ),
@@ -166,12 +143,12 @@ class _PlayerRouteState extends State<PlayerRoute> {
     final chosenService = BlocProvider.getDependency<ChosenClassService>();
 
     return chosenService.isFavoriteValueListenableBuilder(
-      _currMedia.source,
+      media.source,
       builder: (context, isFavorite) => Center(
         child: IconButton(
           iconSize: Theme.of(context).iconTheme.size!,
           onPressed: () =>
-              chosenService.set(source: _currMedia, isFavorite: !isFavorite),
+              chosenService.set(source: media, isFavorite: !isFavorite),
           icon: Icon(
             isFavorite ? Icons.favorite : Icons.favorite_border,
             color: isFavorite ? Colors.red : null,

--- a/app/lib/widgets/media-list/next-media-button.dart
+++ b/app/lib/widgets/media-list/next-media-button.dart
@@ -3,6 +3,7 @@ import 'package:bloc_pattern/bloc_pattern.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:inside_chassidus/util/chosen-classes/chosen-class-service.dart';
+import 'package:inside_chassidus/util/library-navigator/library-position-service.dart';
 import 'package:inside_data_flutter/inside_data_flutter.dart';
 import 'package:just_audio_handlers/just_audio_handlers.dart';
 
@@ -21,6 +22,7 @@ class NextMediaButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final audioHandler = BlocProvider.getDependency<AudioHandler>();
+    final libraryPositionService = BlocProvider.getDependency<LibraryPositionService>();
 
     return StreamBuilder<PositionState>(
       stream: getPositionState(audioHandler),
@@ -29,8 +31,7 @@ class NextMediaButton extends StatelessWidget {
 
         if (media != null) {
           onPressed = () {
-            if (this.onPressed != null)
-              this.onPressed!();
+            libraryPositionService.setActiveItem(media);
 
             if (snapshot.hasData && snapshot.data!.state.playing)
               audioHandler.playFromMediaId(media!.source);

--- a/app/lib/widgets/media-list/next-media-button.dart
+++ b/app/lib/widgets/media-list/next-media-button.dart
@@ -1,0 +1,50 @@
+import 'package:audio_service/audio_service.dart';
+import 'package:bloc_pattern/bloc_pattern.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:inside_chassidus/util/chosen-classes/chosen-class-service.dart';
+import 'package:inside_data_flutter/inside_data_flutter.dart';
+import 'package:just_audio_handlers/just_audio_handlers.dart';
+
+class NextMediaButton extends StatelessWidget {
+  final Media? media;
+
+  final double iconSize;
+  final VoidCallback? onPressed;
+
+  NextMediaButton({
+    this.media,
+    this.onPressed,
+    this.iconSize = 24
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final audioHandler = BlocProvider.getDependency<AudioHandler>();
+
+    return StreamBuilder<PositionState>(
+      stream: getPositionState(audioHandler),
+      builder: (context, snapshot) {
+        VoidCallback? onPressed = null;
+
+        if (media != null) {
+          onPressed = () {
+            if (this.onPressed != null)
+              this.onPressed!();
+
+            if (snapshot.hasData && snapshot.data!.state.playing)
+              audioHandler.playFromMediaId(media!.source);
+
+            BlocProvider.getDependency<ChosenClassService>().set(source: media!, isRecent: true);
+          };
+        }
+
+        return IconButton(
+          onPressed: onPressed,
+          icon: Icon(FontAwesomeIcons.stepForward),
+          iconSize: this.iconSize,
+        );
+      },
+    );
+  }
+}

--- a/app/lib/widgets/media-list/previous-media-button.dart
+++ b/app/lib/widgets/media-list/previous-media-button.dart
@@ -15,8 +15,14 @@ class PreviousMediaButton extends StatelessWidget {
   final double iconSize;
   final VoidCallback? onPressed;
 
+  final String? currentMediaSource;
+
+  String? get _currentMediaSource =>
+      currentMedia?.source ?? currentMediaSource;
+
   PreviousMediaButton({
     this.currentMedia,
+    this.currentMediaSource,
     this.previousMedia,
     this.onPressed,
     this.iconSize = 24
@@ -46,7 +52,7 @@ class PreviousMediaButton extends StatelessWidget {
           };
         } else if (_shouldGoToBeginningOfCurrentMedia(snapshot)) {
           onPressed = () =>
-            positionSaver.set(currentMedia!.source, Duration.zero, handler: audioHandler);
+            positionSaver.set(_currentMediaSource!, Duration.zero, handler: audioHandler);
         }
 
         return IconButton(
@@ -64,7 +70,7 @@ class PreviousMediaButton extends StatelessWidget {
   }
 
   bool _shouldGoToBeginningOfCurrentMedia(AsyncSnapshot<PositionState> snapshot) {
-    return currentMedia != null &&
+    return (currentMedia != null || currentMediaSource != null) &&
         (previousMedia == null || _currentAudioPosition(snapshot) > tenSeconds);
   }
 

--- a/app/lib/widgets/media-list/previous-media-button.dart
+++ b/app/lib/widgets/media-list/previous-media-button.dart
@@ -1,0 +1,77 @@
+import 'package:audio_service/audio_service.dart';
+import 'package:bloc_pattern/bloc_pattern.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:inside_chassidus/util/chosen-classes/chosen-class-service.dart';
+import 'package:inside_data_flutter/inside_data_flutter.dart';
+import 'package:just_audio_handlers/just_audio_handlers.dart';
+
+class PreviousMediaButton extends StatelessWidget {
+  static final Duration tenSeconds = const Duration(seconds: 10);
+
+  final Media? currentMedia;
+  final Media? previousMedia;
+
+  final double iconSize;
+  final VoidCallback? onPressed;
+
+  PreviousMediaButton({
+    this.currentMedia,
+    this.previousMedia,
+    this.onPressed,
+    this.iconSize = 24
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final audioHandler = BlocProvider.getDependency<AudioHandler>();
+    final positionSaver = BlocProvider.getDependency<PositionSaver>();
+
+    return StreamBuilder<PositionState>(
+      stream: getPositionState(audioHandler),
+      builder: (context, snapshot) {
+        VoidCallback? onPressed = null;
+
+        if (_shouldGoToPreviousMedia(snapshot)) {
+          onPressed = () {
+            if (this.onPressed != null)
+              this.onPressed!();
+
+            if (snapshot.hasData && snapshot.data!.state.playing)
+              audioHandler.playFromMediaId(previousMedia!.source);
+
+            BlocProvider.getDependency<ChosenClassService>().set(
+                source: previousMedia!, isRecent: true
+            );
+          };
+        } else if (_shouldGoToBeginningOfCurrentMedia(snapshot)) {
+          onPressed = () =>
+            positionSaver.set(currentMedia!.source, Duration.zero, handler: audioHandler);
+        }
+
+        return IconButton(
+          onPressed: onPressed,
+          icon: Icon(FontAwesomeIcons.stepBackward),
+          iconSize: this.iconSize,
+        );
+      },
+    );
+  }
+
+  bool _shouldGoToPreviousMedia(AsyncSnapshot<PositionState> snapshot) {
+    return previousMedia != null &&
+        _currentAudioPosition(snapshot) < tenSeconds;
+  }
+
+  bool _shouldGoToBeginningOfCurrentMedia(AsyncSnapshot<PositionState> snapshot) {
+    return currentMedia != null &&
+        (previousMedia == null || _currentAudioPosition(snapshot) > tenSeconds);
+  }
+
+  Duration _currentAudioPosition(AsyncSnapshot<PositionState> snapshot) {
+    if (!snapshot.hasData)
+      return Duration.zero;
+    else
+      return snapshot.data!.state.position;
+  }
+}

--- a/app/lib/widgets/media-list/previous-media-button.dart
+++ b/app/lib/widgets/media-list/previous-media-button.dart
@@ -3,6 +3,7 @@ import 'package:bloc_pattern/bloc_pattern.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:inside_chassidus/util/chosen-classes/chosen-class-service.dart';
+import 'package:inside_chassidus/util/library-navigator/library-position-service.dart';
 import 'package:inside_data_flutter/inside_data_flutter.dart';
 import 'package:just_audio_handlers/just_audio_handlers.dart';
 
@@ -13,7 +14,6 @@ class PreviousMediaButton extends StatelessWidget {
   final Media? previousMedia;
 
   final double iconSize;
-  final VoidCallback? onPressed;
 
   final String? currentMediaSource;
 
@@ -24,7 +24,6 @@ class PreviousMediaButton extends StatelessWidget {
     this.currentMedia,
     this.currentMediaSource,
     this.previousMedia,
-    this.onPressed,
     this.iconSize = 24
   });
 
@@ -32,6 +31,7 @@ class PreviousMediaButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final audioHandler = BlocProvider.getDependency<AudioHandler>();
     final positionSaver = BlocProvider.getDependency<PositionSaver>();
+    final libraryPositionService = BlocProvider.getDependency<LibraryPositionService>();
 
     return StreamBuilder<PositionState>(
       stream: getPositionState(audioHandler),
@@ -40,8 +40,7 @@ class PreviousMediaButton extends StatelessWidget {
 
         if (_shouldGoToPreviousMedia(snapshot)) {
           onPressed = () {
-            if (this.onPressed != null)
-              this.onPressed!();
+            libraryPositionService.setActiveItem(previousMedia);
 
             if (snapshot.hasData && snapshot.data!.state.playing)
               audioHandler.playFromMediaId(previousMedia!.source);

--- a/app/lib/widgets/media/audio-button-bar.dart
+++ b/app/lib/widgets/media/audio-button-bar.dart
@@ -43,6 +43,7 @@ class AudioButtonBar extends StatelessWidget {
       children: <Widget>[
         PreviousMediaButton(
           currentMedia: media,
+          currentMediaSource: _mediaSource,
           previousMedia: previousMedia,
           onPressed: onChangedToPreviousMedia,
         ),

--- a/app/lib/widgets/media/audio-button-bar.dart
+++ b/app/lib/widgets/media/audio-button-bar.dart
@@ -16,10 +16,8 @@ class AudioButtonBar extends StatelessWidget {
   final String? mediaSource;
 
   final Media? nextMedia;
-  final VoidCallback? onChangedToNextMedia;
 
   final Media? previousMedia;
-  final VoidCallback? onChangedToPreviousMedia;
 
   String? get _mediaSource => media?.source ?? mediaSource;
 
@@ -27,9 +25,7 @@ class AudioButtonBar extends StatelessWidget {
     required this.media,
     this.mediaSource,
     this.nextMedia,
-    this.onChangedToNextMedia,
     this.previousMedia,
-    this.onChangedToPreviousMedia
   });
 
   @override
@@ -45,7 +41,6 @@ class AudioButtonBar extends StatelessWidget {
           currentMedia: media,
           currentMediaSource: _mediaSource,
           previousMedia: previousMedia,
-          onPressed: onChangedToPreviousMedia,
         ),
         IconButton(
             icon: Icon(FontAwesomeIcons.undo),
@@ -63,7 +58,6 @@ class AudioButtonBar extends StatelessWidget {
         ),
         NextMediaButton(
           media: nextMedia,
-          onPressed: onChangedToNextMedia,
         ),
         _speedButton(handler),
       ],

--- a/app/lib/widgets/media/audio-button-bar.dart
+++ b/app/lib/widgets/media/audio-button-bar.dart
@@ -1,7 +1,10 @@
 import 'package:audio_service/audio_service.dart';
 import 'package:bloc_pattern/bloc_pattern.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:inside_chassidus/widgets/media-list/next-media-button.dart';
+import 'package:inside_chassidus/widgets/media-list/previous-media-button.dart';
 import 'package:inside_data_flutter/inside_data_flutter.dart';
 import 'package:just_audio_handlers/just_audio_handlers.dart';
 import 'package:inside_chassidus/widgets/media-list/play-button.dart';
@@ -12,9 +15,22 @@ class AudioButtonBar extends StatelessWidget {
   /// Set [_mediaSource] if [media] isn't available.
   final String? mediaSource;
 
+  final Media? nextMedia;
+  final VoidCallback? onChangedToNextMedia;
+
+  final Media? previousMedia;
+  final VoidCallback? onChangedToPreviousMedia;
+
   String? get _mediaSource => media?.source ?? mediaSource;
 
-  AudioButtonBar({required this.media, this.mediaSource});
+  AudioButtonBar({
+    required this.media,
+    this.mediaSource,
+    this.nextMedia,
+    this.onChangedToNextMedia,
+    this.previousMedia,
+    this.onChangedToPreviousMedia
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -22,11 +38,13 @@ class AudioButtonBar extends StatelessWidget {
     final positionSaver = BlocProvider.getDependency<PositionSaver>();
 
     return ButtonBar(
+      alignment: MainAxisAlignment.spaceAround,
+      buttonPadding: const EdgeInsets.symmetric(vertical: 8.0),
       children: <Widget>[
-        IconButton(
-          icon: Icon(FontAwesomeIcons.stepBackward),
-          onPressed: () =>
-              positionSaver.set(_mediaSource, Duration.zero, handler: handler),
+        PreviousMediaButton(
+          currentMedia: media,
+          previousMedia: previousMedia,
+          onPressed: onChangedToPreviousMedia,
         ),
         IconButton(
             icon: Icon(FontAwesomeIcons.undo),
@@ -40,10 +58,14 @@ class AudioButtonBar extends StatelessWidget {
         IconButton(
             icon: Icon(FontAwesomeIcons.redo),
             onPressed: () => positionSaver
-                .skip(_mediaSource, Duration(seconds: 15), handler: handler)),
-        _speedButton(handler)
+                .skip(_mediaSource, Duration(seconds: 15), handler: handler)
+        ),
+        NextMediaButton(
+          media: nextMedia,
+          onPressed: onChangedToNextMedia,
+        ),
+        _speedButton(handler),
       ],
-      alignment: MainAxisAlignment.spaceBetween,
     );
   }
 

--- a/inside_data/lib/src/inside_data.dart
+++ b/inside_data/lib/src/inside_data.dart
@@ -62,6 +62,42 @@ class Media extends SiteDataBase implements Comparable {
             parents: parents,
             link: link);
 
+  Future<Section?> getParent(SiteDataLayer siteBoxes) async {
+    if (parents.isEmpty)
+      return null;
+
+    final parentSection = await siteBoxes.section(parents.first);
+
+    // Make sure that the parent exists, and that it really has the data.
+    // This is done in case IDs change etc - we don't want to navigate to library,
+    // to some random place.
+    if (parentSection == null ||
+        !parentSection.content.any((c) => c.media == this)) {
+      return null;
+    }
+
+    return parentSection;
+  }
+
+  Media? getRelativeSibling(Section? parentSection, int relativeIndex) {
+    if (parentSection == null)
+      return null;
+
+    int currContentIndex = -1;
+    for (int i = 0; i < parentSection.content.length; i++) {
+      if (this.id == parentSection.content[i].id) {
+        currContentIndex = i;
+        break;
+      }
+    }
+
+    int siblingIndex = currContentIndex + relativeIndex;
+
+    return siblingIndex >= 0 && siblingIndex < parentSection.content.length ?
+      parentSection.content[siblingIndex].media :
+      null;
+  }
+
   factory Media.fromJson(Map<String, dynamic> json) => _$MediaFromJson(json);
   Map<String, dynamic> toJson() => _$MediaToJson(this);
 


### PR DESCRIPTION
Addresses Issue #100 

- Made PlayerRoute a Stateful Widget so that there shouldn't be a weird jump when switching media (that happens when a new route is pushed)
- Will only go to the previous media if its within the first 10 seconds of the current media. Otherwise it goes back to the beginning.
- The functionality isn't supported from the current media bar (when not in the MediaRoute
- Moved the getParent function to the Media class itself